### PR TITLE
Try class

### DIFF
--- a/src/main/kotlin/org/ionproject/integration/model/internal/Try.kt
+++ b/src/main/kotlin/org/ionproject/integration/model/internal/Try.kt
@@ -1,4 +1,4 @@
-package org.ionproject.integration.`try`
+package org.ionproject.integration.model.internal
 
 sealed class Try<out T> {
 

--- a/src/main/kotlin/org/ionproject/integration/try/Try.kt
+++ b/src/main/kotlin/org/ionproject/integration/try/Try.kt
@@ -39,7 +39,6 @@ sealed class Try<out T> {
     abstract fun orElse(default: Try<@UnsafeVariance T>): Try<T>
 
     abstract fun <U> fold(fa: (Throwable) -> U, fb: (T) -> U): U
-
 }
 
 data class Success<out T>(val value: T) : Try<T>() {

--- a/src/main/kotlin/org/ionproject/integration/try/Try.kt
+++ b/src/main/kotlin/org/ionproject/integration/try/Try.kt
@@ -1,0 +1,65 @@
+package org.ionproject.integration.`try`
+
+sealed class Try<out T> {
+
+    companion object {
+        operator fun <T> invoke(body: () -> T): Try<T> {
+            return try {
+                Success(body())
+            } catch (e: Exception) {
+                Failure(e)
+            }
+        }
+    }
+
+    abstract fun isSuccess(): Boolean
+
+    abstract fun isFailure(): Boolean
+
+    fun <U> map(f: (T) -> U): Try<U> {
+        return when (this) {
+            is Success -> Try {
+                f(this.value)
+            }
+            is Failure -> this as Failure<U>
+        }
+    }
+
+    fun <U> flatMap(f: (T) -> Try<U>): Try<U> {
+        return when (this) {
+            is Success -> f(this.value)
+            is Failure -> this as Failure<U>
+        }
+    }
+
+    abstract fun get(): T
+
+    abstract fun getOrElse(default: @UnsafeVariance T): T
+
+    abstract fun orElse(default: Try<@UnsafeVariance T>): Try<T>
+
+    abstract fun <U> fold(fa: (Throwable) -> U, fb: (T) -> U): U
+
+}
+
+data class Success<out T>(val value: T) : Try<T>() {
+    override fun isSuccess(): Boolean = true
+    override fun isFailure(): Boolean = false
+    override fun getOrElse(default: @UnsafeVariance T): T = value
+    override fun get() = value
+    override fun orElse(default: Try<@UnsafeVariance T>): Try<T> = this
+    override fun <U> fold(fa: (Throwable) -> U, fb: (T) -> U): U = try {
+        fb(value)
+    } catch (e: Exception) {
+        fa(e)
+    }
+}
+
+data class Failure<out T>(val e: Throwable) : Try<T>() {
+    override fun isSuccess(): Boolean = false
+    override fun isFailure(): Boolean = true
+    override fun getOrElse(default: @UnsafeVariance T): T = default
+    override fun get(): T = throw e
+    override fun orElse(default: Try<@UnsafeVariance T>): Try<T> = default
+    override fun <U> fold(fa: (Throwable) -> U, fb: (T) -> U): U = fa(e)
+}

--- a/src/test/kotlin/org/ionproject/integration/model/internal/TryTests.kt
+++ b/src/test/kotlin/org/ionproject/integration/model/internal/TryTests.kt
@@ -1,0 +1,133 @@
+package org.ionproject.integration.model.internal
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class TryTests {
+
+    @Test
+    fun whenOperationEndsInException_ThenTryHoldsFailure() {
+        val tryResult = Try {
+            "3.A".toInt()
+        }
+        assertTrue(tryResult.isFailure())
+    }
+    @Test
+    fun whenOperationEndsInSuccess_ThenTryHoldsValueAndSuccess() {
+        val tryResult: Try<Int> = Try {
+            "2".toInt()
+        }
+        assertTrue(tryResult.isSuccess())
+        assertEquals(2, tryResult.get())
+    }
+    @Test
+    fun whenOperationIsPerformed_ThenItMatchesSuccess() {
+        val tryResult = Try {
+            1 / 0
+        }
+        val result = when (tryResult) {
+            is Failure -> -1
+            is Success -> tryResult.value
+        }
+
+        assertEquals(-1, result)
+    }
+    @Test
+    fun whenOperationIsPerformed_ThenItMatchesFailure() {
+        val tryResult = Try { 2 }
+
+        val result = when (tryResult) {
+            is Failure -> -1
+            is Success -> tryResult.value
+        }
+
+        assertEquals(2, result)
+    }
+    @Test
+    fun whenOperationResultsInException_ThenMapCanContinueToBeCalled() {
+        val tryResult = Try { 2 }
+
+        val tryResult2 = tryResult
+            .map { it * 2 }
+            .map { it.toString() + "t" }
+            .map { it.toInt() }
+
+        assertEquals(Failure<Int>((tryResult2 as Failure).e), tryResult2)
+    }
+    @Test
+    fun whenFlatmapIsCalledOnACleanOperation_ThenItYieldsSuccess() {
+        val tryResult = Try { 2 }
+
+        val tryResult2 = tryResult
+            .flatMap { i -> Try { i * 2 } }
+            .flatMap { i -> Try { i.toString() } }
+
+        assertEquals(Success("4"), tryResult2)
+    }
+    @Test
+    fun whenFlatmapIsCalledWithException_ThenItYieldsFailure() {
+        val tryResult = Try { 2 }
+
+        val tryResult2 = tryResult
+            .flatMap { i -> Try { i * 2 } }
+            .flatMap { i -> Try { i.toString() + "t" } }
+            .flatMap { i -> Try { i.toInt() } }
+
+        assertTrue(tryResult2.isFailure())
+    }
+
+    @Test
+    fun whenOperationResultsInFailure_ThenDefaultValueShouldBeObtained() {
+        val tryResult = Try { 1 }
+
+        assertEquals(tryResult.getOrElse(100), 1)
+
+        val tryResult2 = Try { "3 sad tigers" }
+            .map { it.toInt() }
+            .getOrElse(100)
+
+        assertEquals(100, tryResult2)
+    }
+    @Test
+    fun whenOperationFails_ThenGetThrowsExcetion() {
+        val tryResult = Try {
+            throw RuntimeException("exception")
+        }
+
+        assertThrows<RuntimeException> { tryResult.get() }
+    }
+    @Test
+    fun whenExceptionIsThrownOnTry_ThenOrElseShouldYieldDefault() {
+        val tryResult: Try<Int> = Try {
+            throw RuntimeException("exception")
+        }
+
+        assertEquals(1, tryResult.orElse(Try { 1 }).get())
+    }
+    @Test
+    fun whenOperationIsSuccessful_ThenFoldShouldApplyFb() {
+        val tryResult = Try { 1 }
+
+        val result = tryResult.fold({ m -> m.message }, { n -> n.toString() })
+
+        assertEquals("1", result)
+    }
+    @Test
+    fun whenOperationFails_ThenFoldShouldApplyFa() {
+        val tryResult = Try { throw RuntimeException("something") }
+
+        val result = tryResult.fold({ m -> m.message }, { _ -> throw RuntimeException("else") })
+
+        assertEquals("something", result)
+    }
+    @Test
+    fun whenOperationIsSuccessfulButWithException_ThenFoldShouldApplyFa() {
+        val tryResult = Try { 1 }
+
+        val result = tryResult.fold({ m -> m.message }, { _ -> throw RuntimeException("something") })
+
+        assertEquals("something", result)
+    }
+}


### PR DESCRIPTION
In order to overcome the current limitation of the type Result, that cannot be used as a simple return type. A Try class makes more clear the fact that an operation can have two possible outcomes: success or failure.

This class also includes support for map and flatmap operations.

Closes #52 