### PR TITLE
Add Java 11 as project dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_TAG=8-jdk-alpine
-ARG RUN_TAG=8-jre-alpine
+ARG BUILD_TAG=11-jdk-slim
+ARG RUN_TAG=11.0.7-jre-slim
 
 FROM openjdk:${BUILD_TAG} AS build-env
 WORKDIR /src
@@ -11,7 +11,7 @@ COPY . .
 RUN ./gradlew extractUberJar --no-daemon --stacktrace
 
 FROM openjdk:${RUN_TAG} AS run-env
-RUN addgroup -S spring && adduser -S spring -G spring
+RUN useradd -m spring && usermod -a -G spring spring
 USER spring:spring
 
 ARG EXTRACT_DEPENDENCY_PATH=/src/build/dependency

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,4 @@ COPY --from=build-env ${EXTRACT_DEPENDENCY_PATH}/BOOT-INF/classes /app
 COPY --from=build-env ${EXTRACT_DEPENDENCY_PATH}/BOOT-INF/lib /app/lib
 
 ENTRYPOINT [ "java", "-cp", "app:app/lib/*", "org.ionproject.integration.IOnIntegrationApplicationKt" ]
+


### PR DESCRIPTION
Closes #56 
In order to use Java 11 both for compilation and runtime, the Dockerfile was updated.

Currently there is no alpine image for jdk/jre 11 in the docker hub openjdk page, so the "slim" images were used.

It took around 2m20 to build the project with the new dependencies, which is roughly the same time it took with java 8 (task buildDockerImage).

The adduser command was changed, as its semantics differ from distribution to distribution. It was returning the error "Option s is ambiguous (shell, system)"