### PR TITLE
Investigate how to pass configuration for batch jobs

### DIFF
--- a/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
+++ b/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
@@ -1,7 +1,5 @@
 # ISEL Timetable Batch Job Configurations
-The isel timetable batch job receives as input one or more input files with the extension .properties. The files have to be located in .../src/resources/config/timetable/isel.
-
-Each file will correspond to an execution of the timetable batch job.
+The integration application starts an instance of the ISEL Timetable Batch job for each file present in src/main/resources/config/timetable/isel. The parameters passed for each job instance are the properties contained in a file of that directory.
 
 The following properties are accepted:
 
@@ -12,5 +10,3 @@ The following properties are accepted:
 | localFileDestination     | Path in the local filesystem in which the timetable pdf file is saved. When multiple instances of the job are running simultaneously, this property needs to be specified, otherwise different jobs will be potentially reading and writing on the same file. |
 | pdfRemoteLocation | Url of the timetable pdf to be used on the job. |
 | alertRecipient  | Email of the point-of-contact to notify about job outcome |
-| uploadRetryLimit | Number of times upload should be retried in case I-On Core responds with server error |
-| uploadRetrySleepSeconds | Amount of seconds to wait before retrying upload |

--- a/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
+++ b/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
@@ -12,7 +12,5 @@ The following properties are accepted:
 | localFileDestination     | Path in the local filesystem in which the timetable pdf file is saved. When multiple instances of the job are running simultaneously, this property needs to be specified, otherwise different jobs will be potentially reading and writing on the same file. |
 | pdfRemoteLocation | Url of the timetable pdf to be used on the job. |
 | alertRecipient  | Email of the point-of-contact to notify about job outcome |
-| timetableUploadUrl | Url to upload timetable information |
-| facultyUploadUrl | Url to upload faculty information |
 | uploadRetryLimit | Number of times upload should be retried in case I-On Core responds with server error |
 | uploadRetrySleepSeconds | Amount of seconds to wait before retrying upload |

--- a/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
+++ b/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
@@ -1,5 +1,5 @@
 # ISEL Timetable Batch Job Configurations
-The isel timetable batch job receives as input one or more input files with the extension .properties. The files have to be located in .../src/main/resources/config/timetable/isel.
+The isel timetable batch job receives as input one or more input files with the extension .properties. The files have to be located in .../src/resources/config/timetable/isel.
 
 Each file will correspond to an execution of the timetable batch job.
 

--- a/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
+++ b/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
@@ -1,0 +1,15 @@
+# ISEL Timetable Batch Job Configurations
+The isel timetable batch job receives as input a configuration file with the extension .properties.
+
+The file is specified when the application is launched through the --spring.config.location option. The following properties are accepted:
+
+| Property | Description | Default value |
+|----------|-------------|---------------|
+| local-file-path-key | Key to be used for identifying the timetable pdf path in Spring Batch's execution context | pdf-key |
+| local-file-destination     | Path in the local filesystem in which the timetable pdf file is saved. When multiple instances of the job are running simultaneously, this property needs to be specified, otherwise different jobs will be potentially reading and writing on the same file. | /tmp/TIMETABLE.pdf  |
+| pdf-remote-location | Url of the timetable pdf to be used on the job. | https://www.isel.pt/media/uploads/LEIC_0310.pdf |
+| alert-recipient  | Email of the point-of-contact to notify about job outcome | org.ionproject.integration@gmail.com  |
+| timetable-upload-url | Url to upload timetable information | tbd  |
+| faculty-upload-url | Url to upload faculty information | tbd |
+| upload-retry-limit | Number of times upload should be retried in case I-On Core responds with server error | 3 |
+| upload-retry-sleep-seconds | Amount of seconds to wait before retrying upload | 300 |

--- a/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
+++ b/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
@@ -1,15 +1,17 @@
 # ISEL Timetable Batch Job Configurations
 The isel timetable batch job receives as input a configuration file with the extension .properties.
 
-The file is specified when the application is launched through the --spring.config.location option. The following properties are accepted:
+The file name should be isel-timetable and it is specified when the application is launched through the --spring.config.location option. The following properties are accepted:
 
 | Property | Description | Default value |
 |----------|-------------|---------------|
-| local-file-path-key | Key to be used for identifying the timetable pdf path in Spring Batch's execution context | pdf-key |
-| local-file-destination     | Path in the local filesystem in which the timetable pdf file is saved. When multiple instances of the job are running simultaneously, this property needs to be specified, otherwise different jobs will be potentially reading and writing on the same file. | /tmp/TIMETABLE.pdf  |
-| pdf-remote-location | Url of the timetable pdf to be used on the job. | https://www.isel.pt/media/uploads/LEIC_0310.pdf |
-| alert-recipient  | Email of the point-of-contact to notify about job outcome | org.ionproject.integration@gmail.com  |
-| timetable-upload-url | Url to upload timetable information | tbd  |
-| faculty-upload-url | Url to upload faculty information | tbd |
-| upload-retry-limit | Number of times upload should be retried in case I-On Core responds with server error | 3 |
-| upload-retry-sleep-seconds | Amount of seconds to wait before retrying upload | 300 |
+| localFilePathKey | Key to be used for identifying the timetable pdf path in Spring Batch's execution context | pdf-key |
+| localFileDestination     | Path in the local filesystem in which the timetable pdf file is saved. When multiple instances of the job are running simultaneously, this property needs to be specified, otherwise different jobs will be potentially reading and writing on the same file. | /tmp/TIMETABLE.pdf  |
+| pdfRemoteLocation | Url of the timetable pdf to be used on the job. | https://www.isel.pt/media/uploads/LEIC_0310.pdf |
+| alertRecipient  | Email of the point-of-contact to notify about job outcome | org.ionproject.integration@gmail.com  |
+| timetableUploadUrl | Url to upload timetable information | tbd  |
+| facultyUploadUrl | Url to upload faculty information | tbd |
+| uploadRetryLimit | Number of times upload should be retried in case I-On Core responds with server error | 3 |
+| uploadRetrySleepSeconds | Amount of seconds to wait before retrying upload | 300 |
+
+Properties should be prefixed with isel-timetable (e.g. isel-timetable.localFilePathKey)

--- a/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
+++ b/docs/batch jobs/ISEL timetable extraction batch job/isel-timetable-batch-configuration-file-specification.md
@@ -1,17 +1,18 @@
 # ISEL Timetable Batch Job Configurations
-The isel timetable batch job receives as input a configuration file with the extension .properties.
+The isel timetable batch job receives as input one or more input files with the extension .properties. The files have to be located in .../src/main/resources/config/timetable/isel.
 
-The file name should be isel-timetable and it is specified when the application is launched through the --spring.config.location option. The following properties are accepted:
+Each file will correspond to an execution of the timetable batch job.
 
-| Property | Description | Default value |
-|----------|-------------|---------------|
-| localFilePathKey | Key to be used for identifying the timetable pdf path in Spring Batch's execution context | pdf-key |
-| localFileDestination     | Path in the local filesystem in which the timetable pdf file is saved. When multiple instances of the job are running simultaneously, this property needs to be specified, otherwise different jobs will be potentially reading and writing on the same file. | /tmp/TIMETABLE.pdf  |
-| pdfRemoteLocation | Url of the timetable pdf to be used on the job. | https://www.isel.pt/media/uploads/LEIC_0310.pdf |
-| alertRecipient  | Email of the point-of-contact to notify about job outcome | org.ionproject.integration@gmail.com  |
-| timetableUploadUrl | Url to upload timetable information | tbd  |
-| facultyUploadUrl | Url to upload faculty information | tbd |
-| uploadRetryLimit | Number of times upload should be retried in case I-On Core responds with server error | 3 |
-| uploadRetrySleepSeconds | Amount of seconds to wait before retrying upload | 300 |
+The following properties are accepted:
 
-Properties should be prefixed with isel-timetable (e.g. isel-timetable.localFilePathKey)
+| Property | Description |
+|----------|-------------|
+| pdfKey | Key to be used for identifying the timetable pdf path in Spring Batch's execution context |
+| hashKey | Key to be used for identifying the timetable pdf hash in Spring Batch's execution context |
+| localFileDestination     | Path in the local filesystem in which the timetable pdf file is saved. When multiple instances of the job are running simultaneously, this property needs to be specified, otherwise different jobs will be potentially reading and writing on the same file. |
+| pdfRemoteLocation | Url of the timetable pdf to be used on the job. |
+| alertRecipient  | Email of the point-of-contact to notify about job outcome |
+| timetableUploadUrl | Url to upload timetable information |
+| facultyUploadUrl | Url to upload faculty information |
+| uploadRetryLimit | Number of times upload should be retried in case I-On Core responds with server error |
+| uploadRetrySleepSeconds | Amount of seconds to wait before retrying upload |

--- a/docs/batch jobs/configuration/batch-job-configuration.md
+++ b/docs/batch jobs/configuration/batch-job-configuration.md
@@ -27,21 +27,21 @@ Apart from the default [properties](https://docs.spring.io/spring-boot/docs/curr
 - Launching different instances of the same job would require the properties file to be updated or having a folder per job instance with an application.properties file. To specify the location of the properties file -Dspring.config.location=/path/to/application.properties should be used. Example:
 `java -jar configurations-0.0.1-SNAPSHOT.jar --spring.config.location=./confs/job1/application.properties`
 
-## 3 Additional .properties/.yml files passed in --spring.config.location or spring.config.additional-location
+## 3 Additional .properties/.yml files
 
-What is done for different instances of the same job (having different application.properties files in different folders) can be done to segregate properties across jobs. In practice, we could define a properties file per job instance.
-- Fairly easy to maintain properties segregation, having one config file per job. This would mean that the class where it was used would have to be annotated with @PropertySource if we wanted to change the name of the file to a more meaningful name.
+A properties file per job can be defined. In the cases where the job is defined per course (e.g. the isel timetable job), it is defined a file per course.
+- Fairly easy to maintain properties segregation, having one config file per job.
 - The number of files could grow very fast.
 
-Job configuration files are included in the project's image, in .../resources/config/{batch-name}/{school-name}/{course-name}. The mapping from job to file is 1:N, as for the same job, multiple job instances can be initiated with different configuration files. Each of these relate to a course.
+Job configuration files are included in the project's image, in .../resources/main/config/{batch-name}/{school-name}/.
 
-The configuration file name is static and defined by the team developing the job. 
+The configuration file name can be chosen freely, but for reasons of organization it should be named {school-name}-{course-name}.properties(e.g. isel-leic.properties). There is no need to include the job name in the properties file name because the path of the file already identifies the school.
 
-As an alternative, we could concentrate in one file all configurations for jobs relating to a course. That would not require all configurations to unregistered jobs to be present and would reduce the total number of files. That is a viable option, as for now, the number of configurations is not exceptionally large (8).
+On application launch, the jobs that are to be run are specified, as well as the directories where to look for configuration files. For example, if the timetable job will run for isel and estsl, the method runJob will be executed with the job name and the configuration Path.(e.g. runJob("ISEL Timetable Batch Job","src/main/resources/config/timetable/isel"), and runJob("ISEL Timetable Batch Job","src/main/resources/config/timetable/estsl"))
 
-Defining how to configure jobs is tied to how the spring batch application is launched, because it is at launch time that configurations are provided. The entrypoint command on the Dockerfile calls a script that contains all java commands for initiating spring batch applications, each with different configuration.
+This method will list all the files in the directory. Then, for each file, it will inject its properties on a jobparameters object. Finally, it will start a job instance with the added parameters, including a timestamp in order to be able to run the same job with the same parameters more than once.
 
-Configurations for a job are coerced from the string type whenever possible, to ensure the correctedness of the configurations as soon as possible ([example](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-typesafe-configuration-properties)). Each job's properties are to be designated with a prefix that identifies the job. That way, configurations for one job are abstracted in a single class .
+As said, configurations for a job are passed as strings to job parameters on startup, but before being used they are coerced from the string type whenever possible, to ensure the correctness of the configurations.
 
 ## 4 External database
 
@@ -65,7 +65,7 @@ The only drawback of this, as with command line switches, the java command can b
 
 # Conclusion
 
-After considering the different options we chose to use option 3 - a .properties/.yml file per job.
+After considering the different options we chose to use option 3 - a .properties file per job.
 
 Using an external non-relational database would provide the most flexibility but as it is not otherwise needed, it represents administration overhead, which we cannot absorb at the moment.
 

--- a/docs/batch jobs/configuration/batch-job-configuration.md
+++ b/docs/batch jobs/configuration/batch-job-configuration.md
@@ -1,8 +1,6 @@
 # Goal
 This document aims to weigh in on different options for configuring the integration sub-system batch jobs. Examples of job configuration include the location of the source documents used, whom to notify about job outcome, and where to write the produced information.
 
-Options that would require the application to be compiled in order to change the value associated with a configuration were left out. The application configurations should be provided at launch-time.
-
 In the remainder of the document different alternatives that meet the criteria are discussed, and finally the research conclusion is stated.
 
 # Alternatives
@@ -33,7 +31,7 @@ A properties file per job can be defined. In the cases where the job is defined 
 - Fairly easy to maintain properties segregation, having one config file per job.
 - The number of files could grow very fast.
 
-Job configuration files are included in the project's image, in .../resources/main/config/{batch-name}/{school-name}/.
+Job configuration files are included in the project's image, in .../resources/config/{batch-name}/{school-name}/.
 
 The configuration file name can be chosen freely, but for reasons of organization it should be named {school-name}-{course-name}.properties(e.g. isel-leic.properties). There is no need to include the job name in the properties file name because the path of the file already identifies the school.
 

--- a/docs/batch jobs/configuration/batch-job-configuration.md
+++ b/docs/batch jobs/configuration/batch-job-configuration.md
@@ -33,13 +33,15 @@ What is done for different instances of the same job (having different applicati
 - Fairly easy to maintain properties segregation, having one config file per job. This would mean that the class where it was used would have to be annotated with @PropertySource if we wanted to change the name of the file to a more meaningful name.
 - The number of files could grow very fast.
 
-Job configuration files are stored in a directory in the compute engine VM and can be mounted as a volume when executing the docker run command. That way the docker image could be reused and wouldn't store any configuration files. Doing so, when configurations are changed it shouldn't be necessary to re-build the docker image.
+Job configuration files are included in the project's image, in .../resources/config/{batch-name}/{school-name}/{course-name}. The mapping from job to file is 1:N, as for the same job, multiple job instances can be initiated with different configuration files. Each of these relate to a course.
 
-As the same job can be executed more than once with different configurations (e.g. executing the isel timetable job for two different courses requires different pdf urls), the team developing a job specifies the name of the configuration file. When using different files for executing more than one instance of the same job, the files need to be in different directories.
+The configuration file name is static and defined by the team developing the job. 
 
-For example, suppose we wanted to execute the same job for two courses in the acme school (MechanicalEngineering and Computer Science). Then, we would need to have two directories in our host machine (e.g. acme-school-mechanical-eng and acme-shool-isel-timetable). When running a container instance we would need to mount a volume in /config: `docker run -v /home/user/acme-school-mechanical-eng:/config i-on-integration-image`. Running the same job for the computer science course, we could execute `docker run -v /home/user/acme-school-computer-science:/config i-on-integration-image`.
+As an alternative, we could concentrate in one file all configurations for jobs relating to a course. That would not require all configurations to unregistered jobs to be present and would reduce the total number of files. That is a viable option, as for now, the number of configurations is not exceptionally large (8).
 
-These files can be maintained in a dedicated repository and pulled from it on-demand.
+Defining how to configure jobs is tied to how the spring batch application is launched, because it is at launch time that configurations are provided. The entrypoint command on the Dockerfile calls a script that contains all java commands for initiating spring batch applications, each with different configuration.
+
+Configurations for a job are coerced from the string type whenever possible, to ensure the correctedness of the configurations as soon as possible ([example](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-typesafe-configuration-properties)). Each job's properties are to be designated with a prefix that identifies the job. That way, configurations for one job are abstracted in a single class .
 
 ## 4 External database
 

--- a/docs/batch jobs/configuration/batch-job-configuration.md
+++ b/docs/batch jobs/configuration/batch-job-configuration.md
@@ -1,0 +1,63 @@
+# Goal
+This document aims to weigh in on different options for configuring the integration sub-system batch jobs. Examples of job configuration include the location of the source documents used, whom to notify about job outcome, and where to write the produced information.
+
+Options that would require the application to be compiled in order to change the value associated with a configuration were left out. The application configurations should be provided at launch-time.
+
+In the remainder of the document different alternatives that meet the criteria are discussed, and finally the research conclusion is stated.
+
+# Alternatives
+
+## Command Line switches
+
+Each configuration could be passed with the `--` switch on application launch. For example, if we wanted to associate a key configuration with the value `X` we could do so by launch the app with:
+
+`java -jar i-on-integration.jar --key.config=X`
+
+The value `X` would be available at runtime using the annotation @Value("${key.config}").
+
+- Despite being very simple, this approach is error-prone, as each new configuration would have to be added by hand in the command that launches I-On Integration.
+- It would lead to a large and difficult to read java command.
+- Also, different jobs could not have the same key.
+  
+## Spring configuration application.properties
+
+Apart from the default [properties](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#mail-properties) available at runtime in a spring application, we can define our own inside the application.properties file. This file should be present in a /config subdirectory of the current directory or in the current directory, in the classpath root or in the classpath /config package.
+
+- The main issue with this option is that the configuration file will grow in size as new batch jobs are added. In the long run, that can cause bloating.
+- Launching different instances of the same job would require the properties file to be updated or having a folder per job instance with an application.properties file. To specify the location of the properties file -Dspring.config.location=/path/to/application.properties should be used. Example:
+`java -jar configurations-0.0.1-SNAPSHOT.jar --spring.config.location=./confs/job1/application.properties`
+
+## Additional .properties/.yml files passed in --spring.config.location or spring.config.additional-location
+
+What is done for different instances of the same job (having different application.properties files in different folders) can be done to segregate properties across jobs. In practice, we could define a properties file per job instance.
+- Fairly easy to maintain properties segregation, having one config file per job. This would mean that the class where it was used would have to be annotated with @PropertySource if we wanted to change the name of the file to a more meaningful name.
+- The number of files could grow very fast.
+
+## External database
+
+Parameterizing a job would require having an external unique identifier for a job instance.
+If we used a relational db, the read times would be larger than using config files or command line arguments or job parameters.
+If we used a non-relational db, we would have to configure and maintain it.
+
+## Passing custom configuration file to be parsed by a custom module
+
+Requires more development time, which is not available at the moment. There is no guarantee that the final result is better than using job parameters or the spring application.properties.
+
+## Using job parameters
+Spring Batch provides a way to pass external configuration to a job through the command line. It is similar to command line switches, but with no --.
+
+Example:
+`java -jar configurations-0.0.1-SNAPSHOT.jar key=value key2=value2`
+
+Parameter type is inferred. As parameters are stored in column of a relational db, the supported types are Date, Double, Long and String, as seen [here](https://docs.spring.io/spring-batch/docs/4.2.x/api/org/springframework/batch/core/JobParametersBuilder.html).
+
+The only drawback of this, as with command line switches, the java command can become very large if the number of parameters grows.
+
+# Conclusion
+
+From what was gathered, the two strongest options for this task would be using a .properties/.yml file per job or using Spring Batch Job Parameters.
+
+Using an external non-relational database would provide the most flexibility but as it is not otherwise needed, it represents administration overhead, which we cannot absorb at the moment.
+Having a custom configuration file would require development of a module for parsing it. Having a .properties file per job acchieves the same result and does not require additional development time.
+
+Using Job Parameters is advised on the standard references for Spring Batch.

--- a/docs/batch jobs/configuration/batch-job-configuration.md
+++ b/docs/batch jobs/configuration/batch-job-configuration.md
@@ -7,7 +7,7 @@ In the remainder of the document different alternatives that meet the criteria a
 
 # Alternatives
 
-## Command Line switches
+## 1 Command Line switches
 
 Each configuration could be passed with the `--` switch on application launch. For example, if we wanted to associate a key configuration with the value `X` we could do so by launch the app with:
 
@@ -19,7 +19,7 @@ The value `X` would be available at runtime using the annotation @Value("${key.c
 - It would lead to a large and difficult to read java command.
 - Also, different jobs could not have the same key.
   
-## Spring configuration application.properties
+## 2 Spring configuration application.properties
 
 Apart from the default [properties](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#mail-properties) available at runtime in a spring application, we can define our own inside the application.properties file. This file should be present in a /config subdirectory of the current directory or in the current directory, in the classpath root or in the classpath /config package.
 
@@ -27,23 +27,31 @@ Apart from the default [properties](https://docs.spring.io/spring-boot/docs/curr
 - Launching different instances of the same job would require the properties file to be updated or having a folder per job instance with an application.properties file. To specify the location of the properties file -Dspring.config.location=/path/to/application.properties should be used. Example:
 `java -jar configurations-0.0.1-SNAPSHOT.jar --spring.config.location=./confs/job1/application.properties`
 
-## Additional .properties/.yml files passed in --spring.config.location or spring.config.additional-location
+## 3 Additional .properties/.yml files passed in --spring.config.location or spring.config.additional-location
 
 What is done for different instances of the same job (having different application.properties files in different folders) can be done to segregate properties across jobs. In practice, we could define a properties file per job instance.
 - Fairly easy to maintain properties segregation, having one config file per job. This would mean that the class where it was used would have to be annotated with @PropertySource if we wanted to change the name of the file to a more meaningful name.
 - The number of files could grow very fast.
 
-## External database
+Job configuration files are stored in a directory in the compute engine VM and can be mounted as a volume when executing the docker run command. That way the docker image could be reused and wouldn't store any configuration files. Doing so, when configurations are changed it shouldn't be necessary to re-build the docker image.
+
+As the same job can be executed more than once with different configurations (e.g. executing the isel timetable job for two different courses requires different pdf urls), the team developing a job specifies the name of the configuration file. When using different files for executing more than one instance of the same job, the files need to be in different directories.
+
+For example, suppose we wanted to execute the same job for two courses in the acme school (MechanicalEngineering and Computer Science). Then, we would need to have two directories in our host machine (e.g. acme-school-mechanical-eng and acme-shool-isel-timetable). When running a container instance we would need to mount a volume in /config: `docker run -v /home/user/acme-school-mechanical-eng:/config i-on-integration-image`. Running the same job for the computer science course, we could execute `docker run -v /home/user/acme-school-computer-science:/config i-on-integration-image`.
+
+These files can be maintained in a dedicated repository and pulled from it on-demand.
+
+## 4 External database
 
 Parameterizing a job would require having an external unique identifier for a job instance.
 If we used a relational db, the read times would be larger than using config files or command line arguments or job parameters.
 If we used a non-relational db, we would have to configure and maintain it.
 
-## Passing custom configuration file to be parsed by a custom module
+## 5 Passing custom configuration file to be parsed by a custom module
 
 Requires more development time, which is not available at the moment. There is no guarantee that the final result is better than using job parameters or the spring application.properties.
 
-## Using job parameters
+## 6 Using job parameters
 Spring Batch provides a way to pass external configuration to a job through the command line. It is similar to command line switches, but with no --.
 
 Example:
@@ -55,8 +63,10 @@ The only drawback of this, as with command line switches, the java command can b
 
 # Conclusion
 
-From what was gathered, the strongest option for this task is using a .properties/.yml file per job.
+After considering the different options we chose to use option 3 - a .properties/.yml file per job.
 
 Using an external non-relational database would provide the most flexibility but as it is not otherwise needed, it represents administration overhead, which we cannot absorb at the moment.
+
 Having a custom configuration file would require development of a module for parsing it. Having a .properties file per job acchieves the same result and does not require additional development time.
+
 Despite being advised on the standard references for Spring Batch, the use Job Parameters raises the same concern as command line switches, i.e. the launch command of the app would be very lengthy. On the other hand, using a .properties file does not have this inconvenient.

--- a/docs/batch jobs/configuration/batch-job-configuration.md
+++ b/docs/batch jobs/configuration/batch-job-configuration.md
@@ -63,10 +63,12 @@ The only drawback of this, as with command line switches, the java command can b
 
 # Conclusion
 
-After considering the different options we chose to use option 3 - a .properties file per job.
+After considering the different options we chose to use a combination of options 3 and 6.
 
 Using an external non-relational database would provide the most flexibility but as it is not otherwise needed, it represents administration overhead, which we cannot absorb at the moment.
 
 Having a custom configuration file would require development of a module for parsing it. Having a .properties file per job acchieves the same result and does not require additional development time.
 
 Despite being advised on the standard references for Spring Batch, the use Job Parameters raises the same concern as command line switches, i.e. the launch command of the app would be very lengthy. On the other hand, using a .properties file does not have this inconvenient.
+
+As we needed to have the same application running multiple instances of the same job in one go, and we also wanted the convenience of changing configuration alone when adding new instances, we ended up going with a hybrid solution between having properties files and using job parameters. Job parameters are used when launching a batch job instance, but they are not passed on the command line. Instead, they are built from properties contained in a file, which needs to be in a designated directory for it to be identified.

--- a/docs/batch jobs/configuration/batch-job-configuration.md
+++ b/docs/batch jobs/configuration/batch-job-configuration.md
@@ -55,9 +55,8 @@ The only drawback of this, as with command line switches, the java command can b
 
 # Conclusion
 
-From what was gathered, the two strongest options for this task would be using a .properties/.yml file per job or using Spring Batch Job Parameters.
+From what was gathered, the strongest option for this task is using a .properties/.yml file per job.
 
 Using an external non-relational database would provide the most flexibility but as it is not otherwise needed, it represents administration overhead, which we cannot absorb at the moment.
 Having a custom configuration file would require development of a module for parsing it. Having a .properties file per job acchieves the same result and does not require additional development time.
-
-Using Job Parameters is advised on the standard references for Spring Batch.
+Despite being advised on the standard references for Spring Batch, the use Job Parameters raises the same concern as command line switches, i.e. the launch command of the app would be very lengthy. On the other hand, using a .properties file does not have this inconvenient.


### PR DESCRIPTION
After analyzing different options for externalizing batch job configuration, a .properties file was the chosen alternative, as it strikes a balance between convenience for a developer launching the app, and flexibility.

Other options lead to a lengthy launch command, which is inconvenient (command line switches and job parameters) or not very adaptive (in-house configuration module parsing a custom configuration file).

Closes #32 