### PR TITLE
Deploy to Google Cloud

### DIFF
--- a/.github/workflows/IOnIntegration_Production.yml
+++ b/.github/workflows/IOnIntegration_Production.yml
@@ -17,13 +17,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup gcloud CLI
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '270.0.0'
+          service_account_email: ${{ secrets.GOOGLE_CLOUD_USER }}
+          service_account_key: ${{ secrets.GOOGLE_CLOUD_PASSWORD }}
+
+      - name: Gcloud as credential helper
+        run: gcloud auth configure-docker
+
       - name: Build image
         id: production_build_image
         run: ./gradlew buildDockerImage
-
-      - name: Log into registry
-        id: production_login_registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         id: production_push_image

--- a/.github/workflows/IOnIntegration_Production.yml
+++ b/.github/workflows/IOnIntegration_Production.yml
@@ -34,3 +34,7 @@ jobs:
       - name: Push image
         id: production_push_image
         run: ./gradlew tagPushDockerImage -PgithubRef=${{ github.ref }}
+
+      - name: Deploy
+        id: integration_deploy
+        run: ./gradlew deploy -PgithubRef=${{ github.ref }}

--- a/.github/workflows/IOnIntegration_Production.yml
+++ b/.github/workflows/IOnIntegration_Production.yml
@@ -6,7 +6,7 @@ on:
       - v*
 
 env:
-  IMAGE_NAME: i-on-integration
+  GCLOUD_PROJECT_ID: ${{ secrets.GOOGLE_CLOUD_PROJECT_ID }}
 
 jobs:
   push_production:

--- a/.github/workflows/IOnIntegration_Staging.yml
+++ b/.github/workflows/IOnIntegration_Staging.yml
@@ -8,7 +8,7 @@ on:
       - 'docs/**'
 
 env:
-  IMAGE_NAME: i-on-integration
+  GCLOUD_PROJECT_ID: ${{ secrets.GOOGLE_CLOUD_PROJECT_ID }}
 
 jobs:
   push_integration:

--- a/.github/workflows/IOnIntegration_Staging.yml
+++ b/.github/workflows/IOnIntegration_Staging.yml
@@ -19,13 +19,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup gcloud CLI
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '270.0.0'
+          service_account_email: ${{ secrets.GOOGLE_CLOUD_USER }}
+          service_account_key: ${{ secrets.GOOGLE_CLOUD_PASSWORD }}
+
+      - name: Gcloud as credential helper
+        run: gcloud auth configure-docker
+
       - name: Build image
         id: integration_build_image
         run: ./gradlew buildDockerImage
-
-      - name: Log into registry
-        id: integration_login_registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         id: integration_push_image

--- a/.github/workflows/IOnIntegration_Staging.yml
+++ b/.github/workflows/IOnIntegration_Staging.yml
@@ -36,4 +36,7 @@ jobs:
       - name: Push image
         id: integration_push_image
         run: ./gradlew tagPushDockerImage
-          
+
+      - name: Deploy
+        id: integration_deploy
+        run: ./gradlew deploy

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,25 @@ tasks.register("tagPushDockerImage") {
     }
 }
 
+tasks.register<Exec>("deploy") {
+    val githubRef = project.properties["githubRef"]
+    val finalDockerTag = githubRef?.toString()?.removePrefix("refs/tags/v") ?: "latest"
+    val containerName = if (githubRef == null) {
+        "i-on-integration-staging"
+    } else {
+        "i-on-integration-production"
+    }
+
+    commandLine(
+        "gcloud",
+        "compute instances",
+        "update-container",
+        "$containerName",
+        "--container-image",
+        "$imageId:$finalDockerTag"
+    )
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ group = "org.ionproject"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
-val imageId = "gcr.io/single-conquest-272617/i-on-project/integration/i-on-integration"
+val imageId = "gcr.io/${System.getenv()["GCLOUD_PROJECT_ID"]}/i-on-project/integration/i-on-integration"
 val tempDockerTag: String = "i-on-integration-image"
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ group = "org.ionproject"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
-val imageId = "docker.pkg.github.com/i-on-project/integration/i-on-integration"
+val imageId = "gcr.io/single-conquest-272617/i-on-project/integration/i-on-integration"
 val tempDockerTag: String = "i-on-integration-image"
 
 repositories {


### PR DESCRIPTION
- Given that GitHub packages requires login to pull public images, we now publish the docker images to Google Cloud Container Registry
- Update workflow to deploy image to Google Cloud VM instance

Closes #5 