### PR TITLE
Refactoring of EmailAlertService and Tests

### DIFF
--- a/src/main/kotlin/org/ionproject/integration/alert/implementations/EmailAlertService.kt
+++ b/src/main/kotlin/org/ionproject/integration/alert/implementations/EmailAlertService.kt
@@ -1,38 +1,12 @@
 package org.ionproject.integration.alert.implementations
 
-import javax.mail.internet.InternetAddress
 import org.ionproject.integration.utils.orThrow
-import org.springframework.mail.javamail.JavaMailSenderImpl
-
-const val EMAIL_HEADER = "i-on integration Alert - Job"
 
 class EmailAlertService(
-    private val jobName: String,
-    private val alertRecipient: String,
-    private val asset: String,
-    private val sender: JavaMailSenderImpl
+    private val channel: EmailAlertChannel
 ) {
 
-    fun sendSuccessEmail(): Boolean {
-        val conf = EmailConfiguration(
-            arrayOf(InternetAddress(alertRecipient)),
-            null,
-            "$EMAIL_HEADER Completed Successfully",
-            "$jobName successfully completed for file: $asset"
-        )
-        val channel = EmailAlertChannel(conf, sender)
-        return channel.send().orThrow()
-    }
-
-    fun sendFailureEmail(message: String): Boolean {
-        val conf = EmailConfiguration(
-            arrayOf(InternetAddress(alertRecipient)),
-            null,
-            "$EMAIL_HEADER Failed",
-            "$jobName failed with message: $message " +
-                "for file $asset"
-        )
-        val channel = EmailAlertChannel(conf, sender)
+    fun sendEmail(): Boolean {
         return channel.send().orThrow()
     }
 }

--- a/src/main/kotlin/org/ionproject/integration/step/chunkbased/writer/AlertOnFailureWriter.kt
+++ b/src/main/kotlin/org/ionproject/integration/step/chunkbased/writer/AlertOnFailureWriter.kt
@@ -1,7 +1,10 @@
 package org.ionproject.integration.step.chunkbased.writer
 
 import java.net.URI
+import org.ionproject.integration.alert.implementations.EmailAlertChannel
 import org.ionproject.integration.alert.implementations.EmailAlertService
+import org.ionproject.integration.utils.EmailUtils
+import org.ionproject.integration.utils.JobResult
 import org.ionproject.integration.utils.Try
 import org.ionproject.integration.utils.orThrow
 import org.slf4j.LoggerFactory
@@ -41,8 +44,17 @@ class AlertOnFailureWriter() : ItemWriter<Try<Boolean>> {
     private fun sendEmail(e: Exception) {
         val filePath = pdfRemoteLocation.toString()
         val asset = filePath.substring(filePath.lastIndexOf('/') + 1, filePath.length)
-        val alertService = EmailAlertService("ISEL Timetable Batch Job", alertRecipient, asset, sender)
-        alertService.sendFailureEmail(e.message!!)
+
+        val conf = EmailUtils.configure(
+            "ISEL Timetable Batch Job",
+            JobResult.FAILED,
+            alertRecipient,
+            asset,
+            e.message
+        )
+        val channel = EmailAlertChannel(conf, sender)
+        val alertService = EmailAlertService(channel)
+        alertService.sendEmail()
         log.info("Email sent successfully")
     }
 }

--- a/src/main/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTasklet.kt
+++ b/src/main/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTasklet.kt
@@ -4,6 +4,7 @@ import java.net.URI
 import java.nio.file.Path
 import java.nio.file.Paths
 import javax.sql.DataSource
+import org.ionproject.integration.alert.implementations.EmailAlertChannel
 import org.ionproject.integration.alert.implementations.EmailAlertService
 import org.ionproject.integration.config.AppProperties
 import org.ionproject.integration.file.implementations.FileComparatorImpl
@@ -13,6 +14,8 @@ import org.ionproject.integration.file.implementations.PDFBytesFormatChecker
 import org.ionproject.integration.hash.implementations.HashRepositoryImpl
 import org.ionproject.integration.step.tasklet.iseltimetable.exceptions.DownloadAndCompareTaskletException
 import org.ionproject.integration.utils.CompositeException
+import org.ionproject.integration.utils.EmailUtils
+import org.ionproject.integration.utils.JobResult
 import org.slf4j.LoggerFactory
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.StepContribution
@@ -122,7 +125,16 @@ class DownloadAndCompareTasklet : Tasklet, StepExecutionListener {
     }
 
     private fun sendEmail(msg: String, asset: String) {
-        val alertService = EmailAlertService("ISEL Timetable Batch Job", alertRecipient, asset, sender)
-        alertService.sendFailureEmail(msg)
+        val conf =
+            EmailUtils.configure(
+                "ISEL Timetable Batch Job",
+                JobResult.FAILED,
+                alertRecipient,
+                asset,
+                msg
+            )
+        val channel = EmailAlertChannel(conf, sender)
+        val alertService = EmailAlertService(channel)
+        alertService.sendEmail()
     }
 }

--- a/src/main/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/PostUploadTasklet.kt
+++ b/src/main/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/PostUploadTasklet.kt
@@ -1,8 +1,11 @@
 package org.ionproject.integration.step.tasklet.iseltimetable.implementations
 
 import javax.sql.DataSource
+import org.ionproject.integration.alert.implementations.EmailAlertChannel
 import org.ionproject.integration.alert.implementations.EmailAlertService
 import org.ionproject.integration.hash.implementations.HashRepositoryImpl
+import org.ionproject.integration.utils.EmailUtils
+import org.ionproject.integration.utils.JobResult
 import org.slf4j.LoggerFactory
 import org.springframework.batch.core.StepContribution
 import org.springframework.batch.core.configuration.annotation.StepScope
@@ -37,7 +40,8 @@ class PostUploadTasklet() : Tasklet {
     override fun execute(contribution: StepContribution, chunkContext: ChunkContext): RepeatStatus? {
         val hr = HashRepositoryImpl(ds)
 
-        val fileHash = chunkContext.stepContext.stepExecution.jobExecution.executionContext.get("file-hash") as ByteArray
+        val fileHash =
+            chunkContext.stepContext.stepExecution.jobExecution.executionContext.get("file-hash") as ByteArray
         hr.putHash(jobId, fileHash)
 
         sendEmail()
@@ -48,8 +52,16 @@ class PostUploadTasklet() : Tasklet {
     private fun sendEmail() {
         val asset = pdfRemoteLocation
             .substring(pdfRemoteLocation.lastIndexOf('/') + 1, pdfRemoteLocation.length)
-        val alertService = EmailAlertService("ISEL Timetable Batch Job", alertRecipient, asset, sender)
-        alertService.sendSuccessEmail()
+        val conf = EmailUtils.configure(
+            "ISEL Timetable Batch Job",
+            JobResult.COMPLETED_SUCCESSFULLY,
+            alertRecipient,
+            asset,
+            null
+        )
+        val channel = EmailAlertChannel(conf, sender)
+        val alertService = EmailAlertService(channel)
+        alertService.sendEmail()
         log.info("Email sent successfully")
     }
 }

--- a/src/main/kotlin/org/ionproject/integration/utils/EmailUtils.kt
+++ b/src/main/kotlin/org/ionproject/integration/utils/EmailUtils.kt
@@ -1,0 +1,25 @@
+package org.ionproject.integration.utils
+
+import javax.mail.internet.InternetAddress
+import org.ionproject.integration.alert.implementations.EmailConfiguration
+
+const val EMAIL_HEADER = "i-on integration Alert - Job"
+
+object EmailUtils {
+    fun configure(
+        jobName: String,
+        result: JobResult,
+        alertRecipient: String,
+        asset: String,
+        message: String?
+    ): EmailConfiguration {
+        val text =
+            "$jobName ${result.name} for file: $asset" + if (result == JobResult.FAILED) " with message $message" else ""
+        return EmailConfiguration(
+            arrayOf(InternetAddress(alertRecipient)),
+            null,
+            "$EMAIL_HEADER ${result.name}",
+            text
+        )
+    }
+}

--- a/src/main/kotlin/org/ionproject/integration/utils/JobResult.kt
+++ b/src/main/kotlin/org/ionproject/integration/utils/JobResult.kt
@@ -1,0 +1,5 @@
+package org.ionproject.integration.utils
+
+enum class JobResult {
+    COMPLETED_SUCCESSFULLY, FAILED
+}

--- a/src/test/kotlin/org/ionproject/integration/IOnIntegrationApplicationTests.kt
+++ b/src/test/kotlin/org/ionproject/integration/IOnIntegrationApplicationTests.kt
@@ -2,30 +2,8 @@ package org.ionproject.integration
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.TestPropertySource
 
 @SpringBootTest
-@TestPropertySource(
-    properties = [
-        "spring.datasource.url = jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName = org.h2.Driver",
-        "spring.datasource.username = sa",
-        "spring.datasource.password = ",
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-    ]
-)
 class IOnIntegrationApplicationTests {
 
     @Test

--- a/src/test/kotlin/org/ionproject/integration/alert/implementations/EmailAlertChannelTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/alert/implementations/EmailAlertChannelTest.kt
@@ -25,34 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.mail.javamail.JavaMailSenderImpl
 import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
-@TestPropertySource(
-    properties = ["email.sender =alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false",
-
-        "spring.datasource.url = jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName = org.h2.Driver",
-        "spring.datasource.username = sa",
-        "spring.datasource.password = ",
-
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-
-        "spring.batch.job.enabled = false",
-
-        "ion.resources-folder = src/test/resources/"
-    ]
-)
 @SpringBootTest
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(

--- a/src/test/kotlin/org/ionproject/integration/file/implementations/FileComparatorImplTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/file/implementations/FileComparatorImplTest.kt
@@ -12,31 +12,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.jdbc.Sql
 
 @SpringBootTest
-@TestPropertySource(
-    properties = [
-        "spring.datasource.url = jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName = org.h2.Driver",
-        "spring.datasource.username = sa",
-        "spring.datasource.password = ",
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-    ]
-)
 internal class FileComparatorImplTest {
     @Autowired
     private lateinit var ds: DataSource

--- a/src/test/kotlin/org/ionproject/integration/hash/implementations/HashRepositoryImplTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/hash/implementations/HashRepositoryImplTest.kt
@@ -7,32 +7,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.jdbc.Sql
 
 @SpringBootTest
-@TestPropertySource(
-    properties = [
-        "email.sender =alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false",
-
-        "spring.datasource.url = jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName = org.h2.Driver",
-        "spring.datasource.username = sa",
-        "spring.datasource.password = ",
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/"
-    ]
-)
 internal class HashRepositoryImplTest {
     @Autowired
     private lateinit var ds: DataSource

--- a/src/test/kotlin/org/ionproject/integration/service/implementations/CoreServiceTests.kt
+++ b/src/test/kotlin/org/ionproject/integration/service/implementations/CoreServiceTests.kt
@@ -42,18 +42,8 @@ internal class CoreServiceTestFixtures {
 @TestPropertySource(
     properties = [
         "ion.core-base-url = https://httpbin.org/",
-        "ion.core-token = test",
         "ion.core-request-timeout-seconds = 5",
-        "ion.resources-folder=src/test/resources/",
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
+        "ion.resources-folder=src/test/resources/"
     ]
 )
 class CoreServiceTests {

--- a/src/test/kotlin/org/ionproject/integration/step/chunkbased/FormatVerifierStepTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/chunkbased/FormatVerifierStepTest.kt
@@ -211,28 +211,7 @@ internal class FormatVerifierStepTestUnexistingFile {
         IOnIntegrationApplication::class
     ]
 )
-@TestPropertySource(
-    properties = [
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false",
-
-        "spring.datasource.url = jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName = org.h2.Driver",
-        "spring.datasource.username = sa",
-        "spring.datasource.password = ",
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/"
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 internal class FormatVerifierStepTestInvalidFormat {
 
@@ -312,28 +291,7 @@ internal class FormatVerifierStepTestInvalidFormat {
         IOnIntegrationApplication::class
     ]
 )
-@TestPropertySource(
-    properties = [
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false",
-
-        "spring.datasource.url = jdbc:h2:mem:testdb",
-        "spring.datasource.driverClassName = org.h2.Driver",
-        "spring.datasource.username = sa",
-        "spring.datasource.password = ",
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/"
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 internal class FormatVerifierStepTestEmptyPath {
 

--- a/src/test/kotlin/org/ionproject/integration/step/chunkbased/FormatVerifierStepTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/chunkbased/FormatVerifierStepTest.kt
@@ -299,8 +299,8 @@ internal class FormatVerifierStepTestInvalidFormat {
         assertEquals(ExitStatus.FAILED.exitCode, je.exitStatus.exitCode)
         val messages: Array<MimeMessage> = testSmtp.receivedMessages
         assertEquals(1, messages.size)
-        assertEquals("i-on integration Alert - Job Failed", messages[0].subject)
-        assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job failed with message: The timetable header changed its format for file LEIC_0310.pdf"))
+        assertEquals("i-on integration Alert - Job FAILED", messages[0].subject)
+        assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job FAILED for file: LEIC_0310.pdf with message The timetable header changed its format"))
     }
 }
 

--- a/src/test/kotlin/org/ionproject/integration/step/chunkbased/processor/FormatVerifierProcessorTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/chunkbased/processor/FormatVerifierProcessorTest.kt
@@ -26,23 +26,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
         BatchAutoConfiguration::class,
         IOnIntegrationApplication::class]
 )
-@TestPropertySource(
-    properties = [
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 internal class FormatVerifierProcessorTest {
 

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTaskletTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTaskletTest.kt
@@ -44,26 +44,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
         IOnIntegrationApplication::class
     ]
 )
-
-@TestPropertySource(
-    properties = [
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-
-        "email.sender =alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 @SpringBootTest
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -172,24 +153,7 @@ internal class DownloadAndCompareTaskletDownloadSuccessfulButHashTheSameAsRecord
         IOnIntegrationApplication::class
     ]
 )
-@TestPropertySource(
-    properties = [
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-
-        "email.sender =alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 internal class DownloadAndCompareTaskletMissingPropertiesTest {
 
@@ -246,24 +210,7 @@ internal class DownloadAndCompareTaskletMissingPropertiesTest {
         IOnIntegrationApplication::class
     ]
 )
-@TestPropertySource(
-    properties = [
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-
-        "email.sender =alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 internal class DownloadAndCompareTaskletUrlNotPdfTest {
 
@@ -320,24 +267,7 @@ internal class DownloadAndCompareTaskletUrlNotPdfTest {
         IOnIntegrationApplication::class
     ]
 )
-@TestPropertySource(
-    properties = [
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-
-        "email.sender =alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 internal class DownloadAndCompareTaskletServerErrorTest {
 
@@ -394,7 +324,6 @@ internal class DownloadAndCompareTaskletServerErrorTest {
             val messages: Array<MimeMessage> = testSmtp.receivedMessages
             assertEquals(1, messages.size)
             assertEquals("i-on integration Alert - Job FAILED", messages[0].subject)
-            val e = GreenMailUtil.getBody(messages[0])
             assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job FAILED for file: 500 with message Server responded with error code 500"))
         } finally {
             file.deleteOnExit()

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTaskletTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTaskletTest.kt
@@ -147,8 +147,8 @@ internal class DownloadAndCompareTaskletDownloadSuccessfulButHashTheSameAsRecord
 
             val messages: Array<MimeMessage> = testSmtp.receivedMessages
             assertEquals(1, messages.size)
-            assertEquals("i-on integration Alert - Job Failed", messages[0].subject)
-            assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job failed with message: File Is equal to last successfully parsed for file LEIC_0310.pdf"))
+            assertEquals("i-on integration Alert - Job FAILED", messages[0].subject)
+            assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job FAILED for file: LEIC_0310.pdf with message File Is equal to last successfully parsed"))
         } finally {
             file.delete()
         }
@@ -393,8 +393,9 @@ internal class DownloadAndCompareTaskletServerErrorTest {
 
             val messages: Array<MimeMessage> = testSmtp.receivedMessages
             assertEquals(1, messages.size)
-            assertEquals("i-on integration Alert - Job Failed", messages[0].subject)
-            assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job failed with message: Server responded with error code 500 for file 500"))
+            assertEquals("i-on integration Alert - Job FAILED", messages[0].subject)
+            val e = GreenMailUtil.getBody(messages[0])
+            assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job FAILED for file: 500 with message Server responded with error code 500"))
         } finally {
             file.deleteOnExit()
         }

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/MappingTaskletTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/MappingTaskletTest.kt
@@ -25,23 +25,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
         IOnIntegrationApplication::class
     ]
 )
-@TestPropertySource(
-    properties = [
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 internal class MappingTaskletTest {
 

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/PostUploadTaskletTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/PostUploadTaskletTest.kt
@@ -41,24 +41,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
         IOnIntegrationApplication::class
     ]
 )
-@TestPropertySource(
-    properties = [
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.resources-folder=src/test/resources/",
-
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
-    ]
-)
+@TestPropertySource("classpath:application.properties")
 @SpringBatchTest
 @SpringBootTest
 internal class PostUploadTaskletTest {

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/PostUploadTaskletTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/PostUploadTaskletTest.kt
@@ -154,8 +154,8 @@ internal class PostUploadTaskletTest {
 
         val messages: Array<MimeMessage> = testSmtp.receivedMessages
         assertEquals(1, messages.size)
-        assertEquals("i-on integration Alert - Job Completed Successfully", messages[0].subject)
-        assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job successfully completed for file: LEIC_0310.pdf"))
+        assertEquals("i-on integration Alert - Job COMPLETED_SUCCESSFULLY", messages[0].subject)
+        assertTrue(GreenMailUtil.getBody(messages[0]).contains("ISEL Timetable Batch Job COMPLETED_SUCCESSFULLY for file: LEIC_0310.pdf"))
     }
 
     private fun initJobParameters(jobId: String): JobParameters {

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/UploadTaskletTests.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/UploadTaskletTests.kt
@@ -52,22 +52,9 @@ internal class UploadTaskletTestFixtures {
 
 @RunWith(MockitoJUnitRunner::class)
 @SpringBootTest
-@TestPropertySource(
+@TestPropertySource("classpath:application.properties",
     properties = [
-        "ion.core-base-url = test",
-        "ion.core-token = test",
-        "ion.core-request-timeout-seconds = 1",
-        "ion.core-retries = 3",
-        "ion.resources-folder = src/test/resources/",
-        "email.sender=alert-mailbox@domain.com",
-        "spring.mail.host = localhost",
-        "spring.mail.username=alert-mailbox@domain.com",
-        "spring.mail.password=changeit",
-        "spring.mail.port=3025",
-        "spring.mail.properties.mail.smtp.auth = false",
-        "spring.mail.protocol = smtp",
-        "spring.mail.properties.mail.smtp.starttls.enable = false",
-        "spring.mail.properties.mail.smtp.starttls.required = false"
+        "ion.core-retries = 3"
     ]
 )
 class UploadTaskletTests {

--- a/src/test/kotlin/org/ionproject/integration/utils/EmailUtilsTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/utils/EmailUtilsTest.kt
@@ -2,7 +2,6 @@ package org.ionproject.integration.utils
 
 import org.ionproject.integration.alert.exceptions.AlertConfigurationException
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 

--- a/src/test/kotlin/org/ionproject/integration/utils/EmailUtilsTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/utils/EmailUtilsTest.kt
@@ -1,0 +1,59 @@
+package org.ionproject.integration.utils
+
+import org.ionproject.integration.alert.exceptions.AlertConfigurationException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class EmailUtilsTest {
+
+    @Test
+    fun whenConfigurationIsSuccessfulAndJobIsCompleted_thenAssertConfsAreFilled() {
+        // Arrange
+        val email = "client@domain.com"
+        val jobName = "test job"
+        val result = JobResult.COMPLETED_SUCCESSFULLY
+        val asset = "file001.doc"
+        // Act
+        val conf =
+            EmailUtils.configure(jobName, result, email, asset, null)
+
+        // Assert
+        assertEquals(1, conf.recipients.size)
+        assertEquals(email, conf.recipients[0].toUnicodeString())
+        assertEquals("i-on integration Alert - Job ${result.name}", conf.subject)
+        assertEquals("$jobName COMPLETED_SUCCESSFULLY for file: $asset", conf.text)
+    }
+    @Test
+    fun whenConfigurationIsSuccessfulAndJobIsFailed_thenAssertConfsAreFilled() {
+        // Arrange
+        val email = "client@domain.com"
+        val jobName = "test job"
+        val result = JobResult.FAILED
+        val asset = "file001.doc"
+        val message = "error x"
+        // Act
+        val conf =
+            EmailUtils.configure(jobName, result, email, asset, message)
+
+        // Assert
+        assertEquals(1, conf.recipients.size)
+        assertEquals(email, conf.recipients[0].toUnicodeString())
+        assertEquals("i-on integration Alert - Job ${result.name}", conf.subject)
+        assertEquals("$jobName FAILED for file: $asset with message $message", conf.text)
+    }
+    @Test
+    fun whenInvalidEmailIsProvided_thenAssertAlertConfigurationIsThrown() {
+        // Arrange
+        val invalidEmail = "client@domain"
+        val jobName = "test job"
+        val result = JobResult.FAILED
+        val asset = "file001.doc"
+        val message = "error x"
+        // Act
+        val ex =
+            assertThrows<AlertConfigurationException> { EmailUtils.configure(jobName, result, invalidEmail, asset, message) }
+        assertEquals("There is an invalid e-mail address in the list of recipients", ex.message)
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,1 +1,29 @@
 spring.datasource.schema=classpath:tests-schema.sql
+
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.batch.job.enabled = false
+
+
+spring.mail.host=localhost
+spring.mail.username=alert-mailbox@domain.com
+spring.mail.password=changeit
+spring.mail.port=3025
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.protocol=smtp
+spring.mail.properties.mail.smtp.starttls.enable=false
+spring.mail.properties.mail.smtp.starttls.required=false
+
+email.sender=alert-mailbox@domain.com
+
+# i-on
+ion.core-base-url=test
+ion.core-token=test
+ion.core-request-timeout-seconds=1
+
+
+
+ion.resources-folder=src/test/resources/


### PR DESCRIPTION
- Eliminated EmailAlertService dependency on JavaMailSenderImpl
- Concentrated configurations for tests in application.properties. Overriding them requires use of @TestPropertySource

Closes #105 
Closes #106 