### PR TITLE
Fix windows tests

### DIFF
--- a/src/main/kotlin/org/ionproject/integration/step/chunkbased/reader/ExtractReader.kt
+++ b/src/main/kotlin/org/ionproject/integration/step/chunkbased/reader/ExtractReader.kt
@@ -44,7 +44,6 @@ class ExtractReader : ItemReader<RawData> {
             val fileHash = fd.digest(path.toFile())
             stepExecution.jobExecution.executionContext.put("file-hash", fileHash)
 
-            path.toFile().delete()
             nItems += 1
 
             return rawData

--- a/src/test/kotlin/org/ionproject/integration/step/chunkbased/FormatVerifierStepTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/chunkbased/FormatVerifierStepTest.kt
@@ -4,6 +4,7 @@ import com.icegreen.greenmail.util.DummySSLSocketFactory
 import com.icegreen.greenmail.util.GreenMail
 import com.icegreen.greenmail.util.GreenMailUtil
 import com.icegreen.greenmail.util.ServerSetupTest
+import java.io.File
 import java.lang.reflect.UndeclaredThrowableException
 import java.nio.file.Paths
 import java.security.Security
@@ -31,7 +32,6 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import java.io.File
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(

--- a/src/test/kotlin/org/ionproject/integration/step/chunkbased/GenericParseAndUploadToCoreStepTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/chunkbased/GenericParseAndUploadToCoreStepTest.kt
@@ -1,10 +1,17 @@
 package org.ionproject.integration.step.chunkbased
 
+import java.io.File
+import java.lang.reflect.UndeclaredThrowableException
+import java.nio.file.Paths
+import java.time.Instant
 import org.ionproject.integration.IOnIntegrationApplication
 import org.ionproject.integration.job.Generic
 import org.ionproject.integration.step.chunkbased.writer.GenericCoreWriter
 import org.ionproject.integration.step.utils.SpringBatchTestUtils
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -23,10 +30,6 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import java.io.File
-import java.lang.reflect.UndeclaredThrowableException
-import java.nio.file.Paths
-import java.time.Instant
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(

--- a/src/test/kotlin/org/ionproject/integration/step/chunkbased/GenericParseAndUploadToCoreStepTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/chunkbased/GenericParseAndUploadToCoreStepTest.kt
@@ -1,17 +1,10 @@
 package org.ionproject.integration.step.chunkbased
 
-import java.io.File
-import java.lang.reflect.UndeclaredThrowableException
-import java.nio.file.Paths
-import java.time.Instant
 import org.ionproject.integration.IOnIntegrationApplication
 import org.ionproject.integration.job.Generic
 import org.ionproject.integration.step.chunkbased.writer.GenericCoreWriter
 import org.ionproject.integration.step.utils.SpringBatchTestUtils
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -30,13 +23,17 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.io.File
+import java.lang.reflect.UndeclaredThrowableException
+import java.nio.file.Paths
+import java.time.Instant
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(
-    classes = [
-        Generic::class,
-        IOnIntegrationApplication::class
-    ]
+        classes = [
+            Generic::class,
+            IOnIntegrationApplication::class
+        ]
 )
 @TestPropertySource("classpath:application.properties")
 internal class GenericParseAndUploadToCoreStepTest {
@@ -67,23 +64,29 @@ internal class GenericParseAndUploadToCoreStepTest {
 
     private fun initJobParameters(jobType: String): JobParameters {
         return JobParametersBuilder()
-            .addString("alertRecipient", "org.ionproject@gmail.com")
-            .addString("jobType", jobType)
-            .addLong("timestamp", Instant.now().toEpochMilli())
-            .toJobParameters()
+                .addString("alertRecipient", "org.ionproject@gmail.com")
+                .addString("jobType", jobType)
+                .addLong("timestamp", Instant.now().toEpochMilli())
+                .toJobParameters()
     }
 
+    /* Calculating file hashes in windows yields a different result than in unix/linux.
+    * the value for expected hash in windows is:
+    *  byteArrayOf(-112, -126, -94, 59, -4, -97, 89, 44, 107, -8, 21,
+                -34, -57, -3, -117, 25, 84, -2, 107, -89, -6, -8, -23, -64, 61, 89, 7, -76, -124, -92, -44, 58)
+    * */
     @Test
     fun whenAcademicCalendarIsSuccessfullyParsed_thenAssertFileDoesNotExistAndHashIsInContext() {
         val expectedHash = byteArrayOf(
-            96, 69, -9, 111, -77, 28, 84, 84, -5, -51, 32, 2, -29, -125, 107, -91, 10,
-            10, 101, -96, -99, -115, 35, 114, -88, 108, 111, 123, 27, 85, -47, 38
+                96, 69, -9, 111, -77, 28, 84, 84, -5, -51, 32, 2, -29, -125, 107, -91, 10,
+                10, 101, -96, -99, -115, 35, 114, -88, 108, 111, 123, 27, 85, -47, 38
         )
+
         val path = Paths.get(
-            "src/test/resources/org/ionproject/integration/step/chunkbased" +
-                "/generic/academic-calendar/academic-calendar.yml"
+                "src/test/resources/org/ionproject/integration/step/chunkbased" +
+                        "/generic/academic-calendar/academic-calendar.yml".replace("/", File.separator)
         )
-        val temp = File("src/test/resources/school-a.yml")
+        val temp = File("src/test/resources/school-a.yml".replace("/", File.separator))
         path.toFile().copyTo(temp)
         val jp = initJobParameters("ACADEMIC_CALENDAR")
         val ec = SpringBatchTestUtils().createExecutionContext()
@@ -93,19 +96,27 @@ internal class GenericParseAndUploadToCoreStepTest {
         val actualHash = je.executionContext["file-hash"] as ByteArray
 
         assertFalse(temp.exists())
+        actualHash.forEach { print("$it, ") }
         assertTrue(expectedHash.contentEquals(actualHash))
         Mockito.verify(writer, times(1)).write(Mockito.anyList())
     }
+
+    /*Calculating file hashes in windows yields a different result than in unix/linux.
+    * the value for expected hash in windows is:
+    * byteArrayOf(85, 47, 92, -18, -57, 124, -33, 31, 83, 31, 122, 4, 103, 21, -113, -61, -89,
+                -92, -94, -24, -22, 105, -120, 121, -28, -103, -3, 81, -48, -61, -79, -10)
+     */
     @Test
     fun whenExamScheduleIsSuccessfullyParsed_thenAssertFileDoesNotExistAndHashIsInContext() {
         val expectedHash = byteArrayOf(
-            -55, -84, 127, -43, 94, -70, -94, 86, -116, -32, -95, 75, -109, -111, 82, 93,
-            98, 113, -10, 37, -30, -117, 64, 2, -2, 40, 107, -121, 126, 53, -55, 81
+                -55, -84, 127, -43, 94, -70, -94, 86, -116, -32, -95, 75, -109, -111, 82, 93,
+                98, 113, -10, 37, -30, -117, 64, 2, -2, 40, 107, -121, 126, 53, -55, 81
         )
+
         val path = Paths.get(
-            "src/test/resources/org/ionproject/integration/step/chunkbased/generic/exam-schedule/exam-schedule.yml"
+                "src/test/resources/org/ionproject/integration/step/chunkbased/generic/exam-schedule/exam-schedule.yml".replace("/", File.separator)
         )
-        val temp = File("src/test/resources/school-a.yml")
+        val temp = File("src/test/resources/school-a.yml".replace("/", File.separator))
         path.toFile().copyTo(temp)
         val jp = initJobParameters("EXAM_SCHEDULE")
         val ec = SpringBatchTestUtils().createExecutionContext()
@@ -115,15 +126,17 @@ internal class GenericParseAndUploadToCoreStepTest {
         val actualHash = je.executionContext["file-hash"] as ByteArray
 
         assertFalse(temp.exists())
+        actualHash.forEach { print("$it, ") }
         assertTrue(expectedHash.contentEquals(actualHash))
         Mockito.verify(writer, times(1)).write(Mockito.anyList())
     }
+
     @Test
     fun whenFileIsMismatchedWithJobType_thenThrowYamlException() {
         val path = Paths.get(
-            "src/test/resources/org/ionproject/integration/step/chunkbased/generic/exam-schedule/exam-schedule.yml"
+                "src/test/resources/org/ionproject/integration/step/chunkbased/generic/exam-schedule/exam-schedule.yml".replace("/", File.separator)
         )
-        val temp = File("src/test/resources/school-a.yml")
+        val temp = File("src/test/resources/school-a.yml".replace("/", File.separator))
         path.toFile().copyTo(temp)
         val jp = initJobParameters("ACADEMIC_CALENDAR")
         val ec = SpringBatchTestUtils().createExecutionContext()
@@ -139,13 +152,14 @@ internal class GenericParseAndUploadToCoreStepTest {
         assertEquals("Invalid yaml", ex.undeclaredThrowable.message)
         Mockito.verify(writer, times(0)).write(Mockito.anyList())
     }
+
     @Test
     fun whenJobTypeDoesNotExist_thenThrowIllegaArgumentException() {
         val path = Paths.get(
-            "src/test/resources/org/ionproject/integration/step/chunkbased" +
-                "/generic/academic-calendar/academic-calendar.yml"
+                "src/test/resources/org/ionproject/integration/step/chunkbased" +
+                        "/generic/academic-calendar/academic-calendar.yml".replace("/", File.separator)
         )
-        val temp = File("src/test/resources/school-a.yml")
+        val temp = File("src/test/resources/school-a.yml".replace("/", File.separator))
         path.toFile().copyTo(temp)
         val jp = initJobParameters("DUMMY")
         val ec = SpringBatchTestUtils().createExecutionContext()
@@ -157,8 +171,8 @@ internal class GenericParseAndUploadToCoreStepTest {
         assertEquals(ExitStatus.FAILED.exitCode, je.exitStatus.exitCode)
         assertEquals("IllegalArgumentException", exceptions[0]::class.java.simpleName)
         assertEquals(
-            "No enum constant org.ionproject.integration.model.internal.generic.JobType.DUMMY",
-            exceptions[0].message
+                "No enum constant org.ionproject.integration.model.internal.generic.JobType.DUMMY",
+                exceptions[0].message
         )
         assertFalse(temp.exists())
         assertNull(je.executionContext["file-hash"])
@@ -167,7 +181,7 @@ internal class GenericParseAndUploadToCoreStepTest {
 
     @Test
     fun whenPathDoesNotExist_thenThrowYamlException() {
-        val temp = File("src/test/resources/dummy")
+        val temp = File("src/test/resources/dummy".replace("/", File.separator))
         val jp = initJobParameters("ACADEMIC_CALENDAR")
         val ec = SpringBatchTestUtils().createExecutionContext()
         ec.put("file-path", temp.toPath())
@@ -178,8 +192,8 @@ internal class GenericParseAndUploadToCoreStepTest {
         assertEquals(ExitStatus.FAILED.exitCode, je.exitStatus.exitCode)
         assertEquals("YAMLException", exceptions.undeclaredThrowable::class.java.simpleName)
         assertEquals(
-            "File src/test/resources/dummy does not exist or is a directory.",
-            exceptions.undeclaredThrowable.message
+                "File ${temp.path} does not exist or is a directory.",
+                exceptions.undeclaredThrowable.message
         )
         assertFalse(temp.exists())
         assertNull(je.executionContext["file-hash"])

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTaskletTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTaskletTest.kt
@@ -286,7 +286,7 @@ internal class DownloadAndCompareTaskletUrlNotPdfTest {
     @Test
     fun whenUrlIsNotPdf_ThenAssertExceptionIsInvalidFormatAndPathIsNotIncludedInContext() {
         testSmtp.setUser("alert-mailbox@domain.com", "changeit")
-        val localFileDestination = "src"+ File.separator + "test" + File.separator + "resources"
+        val localFileDestination = "src" + File.separator + "test" + File.separator + "resources"
         val pathKey = "file-path"
         val ec = utils.createExecutionContext()
         val jp = initJobParameters()

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTaskletTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/DownloadAndCompareTaskletTest.kt
@@ -286,7 +286,7 @@ internal class DownloadAndCompareTaskletUrlNotPdfTest {
     @Test
     fun whenUrlIsNotPdf_ThenAssertExceptionIsInvalidFormatAndPathIsNotIncludedInContext() {
         testSmtp.setUser("alert-mailbox@domain.com", "changeit")
-        val localFileDestination = "src/test/resources"
+        val localFileDestination = "src"+ File.separator + "test" + File.separator + "resources"
         val pathKey = "file-path"
         val ec = utils.createExecutionContext()
         val jp = initJobParameters()

--- a/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/PostUploadTaskletTest.kt
+++ b/src/test/kotlin/org/ionproject/integration/step/tasklet/iseltimetable/implementations/PostUploadTaskletTest.kt
@@ -157,7 +157,6 @@ internal class PostUploadTaskletTest {
         val messages: Array<MimeMessage> = testSmtp.receivedMessages
         assertEquals(1, messages.size)
         assertEquals("i-on integration Alert - Job COMPLETED_SUCCESSFULLY", messages[0].subject)
-        val e = GreenMailUtil.getBody(messages[0])
         assertTrue(GreenMailUtil.getBody(messages[0]).contains("TestJob COMPLETED_SUCCESSFULLY for file: LEIC_0310.pdf"))
     }
 


### PR DESCRIPTION
- Some tests were failing because of path separators in conversion to path
- 2 tests are still failing but have comments on them explaining where and how they can pass.

Closes #116 