### PR TITLE
add support for variable-argument Try::map function

### DIFF
--- a/src/main/kotlin/org/ionproject/integration/utils/Try.kt
+++ b/src/main/kotlin/org/ionproject/integration/utils/Try.kt
@@ -64,6 +64,23 @@ sealed class Try<out T> {
                     is Error -> Error(merge(a.e, b.e))
                 }
             }
+
+        fun <T, R> map(vararg values: Try<T>, f: (List<T>) -> R): Try<R> {
+            data class Holder(val list: MutableList<T> = mutableListOf(), var error: Error? = null)
+
+            val data = values.fold(Holder()) { holder, item ->
+                holder.apply {
+                    when (item) {
+                        is Value -> list += item.value
+                        is Error -> {
+                            val exception = error?.let { merge(it.e, item.e) } ?: item.e
+                            error = Error(exception)
+                        }
+                    }
+                }
+            }
+            return data.error ?: of { f(data.list) }
+        }
     }
 }
 

--- a/src/test/kotlin/org/ionproject/integration/utils/TryTests.kt
+++ b/src/test/kotlin/org/ionproject/integration/utils/TryTests.kt
@@ -1,5 +1,6 @@
 package org.ionproject.integration.utils
 
+import org.ionproject.integration.utils.Try.Companion.ofValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -79,7 +80,7 @@ class TryTests {
     @Test
     fun whenOfValue_thenValueInstance() {
         // Act
-        val result = Try.ofValue(1)
+        val result = ofValue(1)
 
         // Assert
         assertEquals(1, result.orThrow())
@@ -146,5 +147,36 @@ class TryTests {
         assertEquals(2, e.exceptions.count())
         assertEquals(true, e.exceptions[0] is ArithmeticException)
         assertEquals(true, e.exceptions[1] is NullPointerException)
+    }
+
+    @Test
+    fun `map using multiple int arguments and return result`() {
+        val result = Try.map(ofValue(1), ofValue(3), ofValue(2)) { it.sum() }
+            .orElse { it.javaClass.simpleName }
+
+        assertEquals(6, result)
+    }
+
+    @Test
+    fun `map using multiple string arguments and return result`() {
+        val result = Try.map(
+            ofValue("foo"),
+            ofValue("bar"),
+            ofValue("baz"),
+            ofValue("!")
+        ) { it.joinToString(separator = " ") }
+            .orElse { it.javaClass.simpleName }
+
+        assertEquals("foo bar baz !", result)
+    }
+
+    @Test
+    fun `map using multiple int arguments and throwing arithmetic exception when dividing by zero`() {
+        val result =
+            Try.map(oper(1, 1), oper(122, 0), oper(3, 0), oper(-1, 0)) { it.sum() }
+
+        val e = assertThrows<CompositeException> { result.orThrow() }
+        assertEquals(3, e.exceptions.count())
+        assertTrue { e.exceptions.all { it is ArithmeticException } }
     }
 }


### PR DESCRIPTION
actually created this while working on #138 as it was proving useful to support multiple arguments in Try::map but it felt like it should be it's own PR so I cherry-picked the commit into this solo branch for easier review.