### PR TITLE
update PR workflow to ignore Draft PRs

### DIFF
--- a/.github/workflows/IOnIntegration_PR.yml
+++ b/.github/workflows/IOnIntegration_PR.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout


### PR DESCRIPTION
update PR workflow to ignore Draft PRs and avoid running unnecessary builds on WIP