### PR TITLE
Dispatcher interface

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,6 @@ repositories {
 }
 
 dependencies {
-    implementation(project(":file-repository"))
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-batch")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")

--- a/app/src/main/kotlin/org/ionproject/integration/model/Dispatcher.kt
+++ b/app/src/main/kotlin/org/ionproject/integration/model/Dispatcher.kt
@@ -6,22 +6,20 @@ import org.ionproject.integration.model.external.timetable.TimetableDto
  * This file contains the interfaces that must be implemented by Dispatcher modules (i.e. FileRepository).
  * It also contains all the auxiliary data classes and enums.
  */
+
+/**
+ * Interface definitions
+ */
 interface IDispatcher<T : ParsedData> {
     fun dispatch(data: T, format: OutputFormat): DispatchResult
 }
 
 interface ITimetableDispatcher<TimetableData>
 
-enum class OutputFormat {
-    YAML,
-    JSON
-}
-
-enum class DispatchResult {
-    SUCCESS,
-    FAILURE
-}
-
+/**
+ * ParsedData will be used to "transport" the final data along with the required metadata.
+ * A new implementation should be added for each file type and matching IDispatcher interface.
+ */
 sealed class ParsedData(val data: Any)
 
 data class TimetableData(
@@ -46,6 +44,16 @@ data class CalendarTerm(
     val startYear: Int,
     val term: Term
 )
+
+enum class OutputFormat {
+    YAML,
+    JSON
+}
+
+enum class DispatchResult {
+    SUCCESS,
+    FAILURE
+}
 
 enum class Term(val number: Int) {
     FALL(1),

--- a/app/src/main/kotlin/org/ionproject/integration/model/Dispatcher.kt
+++ b/app/src/main/kotlin/org/ionproject/integration/model/Dispatcher.kt
@@ -1,0 +1,53 @@
+package org.ionproject.integration.model
+
+import org.ionproject.integration.model.external.timetable.TimetableDto
+
+/**
+ * This file contains the interfaces that must be implemented by Dispatcher modules (i.e. FileRepository).
+ * It also contains all the auxiliary data classes and enums.
+ */
+interface IDispatcher<T : ParsedData> {
+    fun dispatch(data: T, format: OutputFormat): DispatchResult
+}
+
+interface ITimetableDispatcher<TimetableData>
+
+enum class OutputFormat {
+    YAML,
+    JSON
+}
+
+enum class DispatchResult {
+    SUCCESS,
+    FAILURE
+}
+
+sealed class ParsedData(val data: Any)
+
+data class TimetableData(
+    val programme: ProgrammeMetadata,
+    val term: CalendarTerm,
+    private val dto: TimetableDto
+) : ParsedData(dto)
+
+data class InstitutionMetadata(
+    val name: String,
+    val acronym: String,
+    val domain: String
+)
+
+data class ProgrammeMetadata(
+    val institutionMetadata: InstitutionMetadata,
+    val name: String,
+    val acronym: String
+)
+
+data class CalendarTerm(
+    val startYear: Int,
+    val term: Term
+)
+
+enum class Term(val number: Int) {
+    FALL(1),
+    SPRING(2)
+}

--- a/file-repository/build.gradle.kts
+++ b/file-repository/build.gradle.kts
@@ -13,6 +13,9 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
+    implementation(project(":app"))
     implementation("org.springframework.boot:spring-boot-starter")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.3")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }


### PR DESCRIPTION
file-repository now depends on app and not the other way around
create Dispatcher interface definition and all currently necessary support classes and interfaces. This may be broken into further files later but atm it feels like an atomic unit of data that should remain physically close.

Closes #181 