### PR TITLE
Added env variables in Staging workflow

### DIFF
--- a/.github/workflows/IOnIntegration_Staging.yml
+++ b/.github/workflows/IOnIntegration_Staging.yml
@@ -23,3 +23,5 @@ jobs:
           heroku_email: ${{secrets.HEROKU_EMAIL}}
           usedocker: true
           docker_heroku_process_type: web
+        env:
+          SQL_HOST: ${{secrets.HEROKU_SQL_HOST}}/${{secrets.HEROKU_SQL_DATABASE}}?sslmode=require&user=${{secrets.HEROKU_SQL_USER}}&password=${{secrets.HEROKU_SQL_PASSWORD}}

--- a/.github/workflows/IOnIntegration_Staging.yml
+++ b/.github/workflows/IOnIntegration_Staging.yml
@@ -16,7 +16,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup ACT test environment
+        if: ${{ env.ACT }}
+        run: curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
+
+      - name: Retrieve Database URL
+        id: databaseUrl
+        run: echo "::set-output name=url::$(heroku config:get DATABASE_URL -a ${{secrets.HEROKU_APP_NAME}})"
+
+      - uses: rishabhgupta/split-by@v1
+        id: split1
+        with:
+          string: ${{steps.databaseUrl.outputs.url}}
+          split-by: '@'
+
+      - uses: rishabhgupta/split-by@v1
+        id: split2
+        with:
+          string: ${{steps.split1.outputs._0}}
+          split-by: ':'
+
+      - uses: rishabhgupta/split-by@v1
+        id: split3
+        with:
+          string: ${{steps.split2.outputs._1}}
+          split-by: '/'
+
       - uses: akhileshns/heroku-deploy@v3.12.12
+        if: ${{ !env.ACT }}
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: ${{secrets.HEROKU_APP_NAME}}
@@ -24,7 +51,8 @@ jobs:
           usedocker: true
           docker_heroku_process_type: web
           healthcheck: "https://${{secrets.HEROKU_APP_NAME}}.herokuapp.com/health"
-       -id: databaseUrl
-        run: echo "::set-output name=url::$(heroku config:get DATABASE_URL -a ${{secrets.HEROKU_APP_NAME}})"
         env:
-          HEROKU_DB_URL: ${{steps.databaseUrl.outputs.url}}
+          HD_SQL_HOST: jdbc:postgresql://${{ steps.split1.outputs._1}}
+          HD_SQL_USER: ${{ steps.split3.outputs._2}}
+          HD_SQL_PASSWORD: ${{ steps.split2.outputs._2}}
+

--- a/.github/workflows/IOnIntegration_Staging.yml
+++ b/.github/workflows/IOnIntegration_Staging.yml
@@ -23,5 +23,8 @@ jobs:
           heroku_email: ${{secrets.HEROKU_EMAIL}}
           usedocker: true
           docker_heroku_process_type: web
+          healthcheck: "https://${{secrets.HEROKU_APP_NAME}}.herokuapp.com/health"
+       -id: databaseUrl
+        run: echo "::set-output name=url::$(heroku config:get DATABASE_URL -a ${{secrets.HEROKU_APP_NAME}})"
         env:
-          SQL_HOST: ${{secrets.HEROKU_SQL_HOST}}/${{secrets.HEROKU_SQL_DATABASE}}?sslmode=require&user=${{secrets.HEROKU_SQL_USER}}&password=${{secrets.HEROKU_SQL_PASSWORD}}
+          HEROKU_DB_URL: ${{steps.databaseUrl.outputs.url}}

--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ git-server/*
 
 ### Ignore stating directory
 staging/*
+
+### Ignore my.secrets file for Github Actions testing tool Act ###
+my.secrets


### PR DESCRIPTION
When using Postgres add-on on Heroku, a VM with a database is created on AWS. This instance is ephemeral so the developer needs to ensure that the information is retrieved dynamically. In this issue, we'll read the `DATABASE_URL` environment variable in Heroku when the GitHub Action workflow for the Heroku staging environment is triggered.

In order to facilitate tests for the workflows, the [act](https://github.com/nektos/act) tool was used to run workflows locally.

After reading the environment variable is read, the [Github Split-By Action](https://github.com/marketplace/actions/split-by) is used to split the string in the data that will form the environmental variables that we'll inject into the container using [Heroku Deploy Github Action](https://github.com/AkhileshNS/heroku-deploy).

The environmental variables injected into the container following the parsing of `DATABASE_URL`:
- `SQL_HOST`
- `SQL_USER`
- `SQL_PASSWORD`

Closes issue #203.